### PR TITLE
Improve logging and optimise Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ stkpconnect-server/libstkpconnect-server.a
 .qmake.stash
 stkpconnect-server/moc_predefs.h
 stkpconnect-plugin/moc_predefs.h
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-from ubuntu:bionic
-RUN apt update -qq
-RUN apt -yq install gnupg ca-certificates apt-transport-https software-properties-common git
-RUN echo "deb http://mirror.mxe.cc/repos/apt bionic main" | tee /etc/apt/sources.list.d/mxeapt.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C6BF758A33A3A276
-RUN apt update -qq
-RUN apt install -yq mxe-x86-64-w64-mingw32.static-qtbase mxe-x86-64-w64-mingw32.static-qtdeclarative
-RUN apt install -yq qtbase5-dev qtdeclarative5-dev qt5-default build-essential
-RUN wget http://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK300.zip
-RUN unzip *.zip
-RUN rm XPSDK300.zip
-RUN mv SDK /XPlaneSDK
+FROM ubuntu:bionic
+RUN apt update -qq && \
+    apt -yq install gnupg ca-certificates apt-transport-https software-properties-common git && \
+    echo "deb http://mirror.mxe.cc/repos/apt bionic main" | tee /etc/apt/sources.list.d/mxeapt.list && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C6BF758A33A3A276 && \
+    apt update -qq && \
+    apt install -yq mxe-x86-64-w64-mingw32.static-qtbase mxe-x86-64-w64-mingw32.static-qtdeclarative \
+    qtbase5-dev qtdeclarative5-dev qt5-default build-essential lzip libgtk2.0-dev && \
+    wget http://developer.x-plane.com/wp-content/plugins/code-sample-generation/sample_templates/XPSDK300.zip &&\
+    unzip *.zip && \
+    rm XPSDK300.zip && \
+    mv SDK /XPlaneSDK

--- a/stkpconnect-server/tcpclient.cpp
+++ b/stkpconnect-server/tcpclient.cpp
@@ -108,7 +108,7 @@ void TcpClient::readClient() {
                         } else if(ref->type() == stkpconnectRefTypeData) {
                             _refValueB[ref] = qobject_cast<DataDataRef*>(ref)->value();
                         }
-                        INFO << "Subscribed to " << ref->name() << ", accuracy " << accuracy << ", type " << ref->typeString() << ", valid " << ref->isValid();
+                        DEBUG << "Subscribed to " << ref->name() << ", accuracy " << accuracy << ", type " << ref->typeString() << ", valid " << ref->isValid();
                     }
                 } else { // Ref already subscribed - update accuracy
                     INFO << "Updating " << refName << " accuracy to " << accuracy;

--- a/stkpconnect-server/tcpserver.cpp
+++ b/stkpconnect-server/tcpserver.cpp
@@ -29,6 +29,11 @@ void TcpServer::setDataRefProvider(DataRefProvider *refProvider) {
     if(m_refProvider) {
         if(!server.listen(QHostAddress::Any, STKPCONNECT_PORT)) {
             INFO << "Unable to listen on port " << STKPCONNECT_PORT;
+
+            // Log the exact reason QtTcpServer is unable to listen on the port.
+            INFO << server.serverError();
+            INFO << server.errorString();
+
             return;
         }
         INFO << "Listening on port " << STKPCONNECT_PORT;

--- a/util/console.h
+++ b/util/console.h
@@ -23,6 +23,6 @@
  *
  * @see qCritical()
  */
-#define INFO qCritical() << "STKPConnect:" << Q_FUNC_INFO
+#define INFO qInfo() << "STKPConnect-Plugin:" << Q_FUNC_INFO
 
 #endif // CONSOLE_H


### PR DESCRIPTION
* Added custom Qt message handler to facilitate more meaningful timestamped logging.
* Plugin logs now get outputted to its own dedicated log file: <X-Plane root>/Output/stkpconnector.log
* Changed a particularly "loud" logging line to DEBUG instead of INFO.
* Added logging for QtTcpServer which will explain why a port could not be listened on.
* Optimised Dockerfile to remove individual RUN layers - should reduce image size and make for faster builds.